### PR TITLE
move underscore to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "merge": "^1.2.0",
     "moment": "^2.15.2",
     "moment-timezone": "^0.5.10",
-    "react-addons-css-transition-group": "^15.3.1"
+    "react-addons-css-transition-group": "^15.3.1",
+    "underscore": "^1.8.3"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0"
@@ -59,7 +60,6 @@
     "react-router": "^2.6.1",
     "react-scripts": "^0.8.3",
     "react-test-renderer": "^15.4.1",
-    "underscore": "^1.8.3",
     "webpack": "^1.14.0"
   },
   "eslintConfig": {


### PR DESCRIPTION
It is used in the source. Example: https://github.com/esnet/react-axis/blob/6e66a0e2e46fb2d57b2e04be8361e8e076734774/src/components/TimeAxis.js#L12